### PR TITLE
Improve descriptions, help texts, error messages, etc

### DIFF
--- a/docs/web_api.md
+++ b/docs/web_api.md
@@ -46,7 +46,7 @@ in the DRF `DEFAULT_PERMISSION_CLASSES` setting.
 
 Our permission class will read your configuration set through admin and will apply it on the selected endpoints.
 
-**Important**: Not only the access of the endpoint will be restricted but also the API documentation it provides will be restricted.
+**Important**: Not only the access of the endpoint will be restricted, but also the API documentation it provides will be restricted.
 
 The available access levels are:
 

--- a/shuup_api/admin_module/views/permissions.py
+++ b/shuup_api/admin_module/views/permissions.py
@@ -18,5 +18,5 @@ class APIPermissionView(FormView):
 
     def form_valid(self, form):
         form.save()
-        messages.success(self.request, _("API permissions saved"))
+        messages.success(self.request, _("Sucecss! API permissions saved."))
         return redirect("shuup_admin:api_permission")

--- a/shuup_api/apps.py
+++ b/shuup_api/apps.py
@@ -28,6 +28,6 @@ class AppConfig(shuup.apps.AppConfig):
         rest_framework_config = getattr(settings, "REST_FRAMEWORK", None)
         if not (rest_framework_config and rest_framework_config.get("DEFAULT_PERMISSION_CLASSES")):
             raise ImproperlyConfigured(
-                "`shuup_api` REQUIRES explicit configuration of `REST_FRAMEWORK['DEFAULT_PERMISSION_CLASSES']` "
+                "Error! `shuup_api` REQUIRES explicit configuration of `REST_FRAMEWORK['DEFAULT_PERMISSION_CLASSES']` "
                 "in your settings file. This is to avoid all of your shop's orders being world-readable-and-writable."
             )

--- a/shuup_api/fields.py
+++ b/shuup_api/fields.py
@@ -27,9 +27,9 @@ class EnumField(serializers.ChoiceField):
     def __init__(self, enum, lenient=False, ints_as_names=False, **kwargs):
         """
         :param enum: The enumeration class.
-        :param lenient: Whether to allow lenient parsing (case-insensitive, by value or name)
+        :param lenient: Whether to allow lenient parsing (case-insensitive, by value or name).
         :type lenient: bool
-        :param ints_as_names: Whether to serialize integer-valued enums by their name, not the integer value
+        :param ints_as_names: Whether to serialize integer-valued enums by their name, not the integer value.
         :type ints_as_names: bool
         """
         self.enum = enum
@@ -49,7 +49,7 @@ class EnumField(serializers.ChoiceField):
                 return instance.name.lower()
             return instance.value
         except ValueError:
-            raise ValueError('Invalid value [%r] of enum %s' % (instance, self.enum.__name__))
+            raise ValueError('Error! Invalid value [%r] of enum %s.' % (instance, self.enum.__name__))
 
     def to_internal_value(self, data):
         if isinstance(data, self.enum):
@@ -86,26 +86,26 @@ class TypedContentFile(ContentFile):
 class Base64FileField(serializers.FileField):
     """
     Inspired in https://github.com/Hipo/drf-extra-fields/blob/master/drf_extra_fields/fields.py
-    But here we use the media type from the header to guess the file type
+    But here we use the media type from the header to guess the file type.
     """
     def to_internal_value(self, base64_data):
         if not isinstance(base64_data, six.string_types):
-            raise ValidationError("This is not a base64 string")
+            raise ValidationError("Error! This is not a base64 string.")
 
         elif ';base64,' not in base64_data:
-            raise ValidationError("base64 files must have media type defined.")
+            raise ValidationError("Error! Proper base64 files must have a media type defined.")
 
         header, base64_data = base64_data.split(';base64,')
 
         try:
             decoded_file = base64.b64decode(base64_data)
         except (TypeError, binascii.Error):
-            raise ValidationError("Invalid file.")
+            raise ValidationError("Error! Invalid file.")
 
         media_type = header[len("data:"):]  # remove data: from the start of the string
         extension = mimetypes.guess_extension(media_type, strict=False)
         if not extension:
-            raise ValidationError("Media type not recognized.")
+            raise ValidationError("Error! Media type was not recognized.")
 
         file_name = "{0}{1}".format(uuid.uuid4(), extension)
         data = TypedContentFile(decoded_file, media_type, name=file_name)
@@ -117,7 +117,7 @@ class Base64FileField(serializers.FileField):
             with open(file.path, 'rb') as f:
                 return "data:{0};base64,{1}".format(mime_type, base64.b64encode(f.read()).decode())
         except Exception:
-            raise IOError("Error encoding file")
+            raise IOError("Error! Error during file encoding.")
 
 
 class FormattedDecimalField(serializers.DecimalField):

--- a/shuup_api/mixins.py
+++ b/shuup_api/mixins.py
@@ -30,13 +30,13 @@ class ProtectedModelViewSetMixin(object):
             return super(ProtectedModelViewSetMixin, self).destroy(request, *args, **kwargs)
         except ProtectedError as exc:
             ref_obj = exc.protected_objects[0].__class__.__name__
-            msg = "This object can not be deleted because it is referenced by {}".format(ref_obj)
+            msg = "Error! This object can not be deleted because it is referenced by {}.".format(ref_obj)
             return Response(data={"error": msg}, status=status.HTTP_400_BAD_REQUEST)
 
 
 class SearchableMixin(object):
     """
-    Mixin to give search capabilities for `ViewSet`
+    Mixin to give search capabilities for `ViewSet`.
     """
     filter_backends = (SearchFilter,)
     search_fields = ("=id",)


### PR DESCRIPTION
This is part of a big update to improve various texts in Shuup.

A lot of changes, touching almost every individual Shuup project's repo.

There are too many changes to try to describe them separately, but the 
main ones are:
1. Improve `help_text` descriptions. Fix typos, rewrite and change, 
write new ones.
2. Change some of the model field names (for example rename 
`available_from` -> `available_since`; `available_to` `available_until` 
- this is in a separate commit).
3. Improve some of the documentation.
4. Improve some in-code-comments.
5. Improve `settings.py` files. It's now clearer what each option does.
6. Change some of the naming.
7. Change the error/message system.

The main Shuup repo's Merge Request is here: 
https://github.com/shuup/shuup/pull/2113 (with a reasoning behind 
changes).